### PR TITLE
Update rabbitmq and erlang to the latest versions and use different repo

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,8 +3,8 @@ rabbitmq_daemon: rabbitmq-server
 rabbitmq_state: started
 rabbitmq_enabled: true
 
-rabbitmq_version: "3.8.5"
-erlang_version: "23.0.2"
+rabbitmq_version: "3.8.16"
+erlang_version: "24.0.1"
 
 rabbitmq_rpm: "rabbitmq-server-{{ rabbitmq_version }}-1.el{{ ansible_distribution_major_version }}.noarch.rpm"
 rabbitmq_rpm_url: "https://packagecloud.io/rabbitmq/rabbitmq-server/packages/el/{{ ansible_distribution_major_version }}/{{ rabbitmq_rpm }}/download"
@@ -16,7 +16,7 @@ rabbitmq_deb: "rabbitmq-server_{{ rabbitmq_version }}-1_all.deb"
 rabbitmq_deb_url: "https://packagecloud.io/rabbitmq/rabbitmq-server/packages/{{ ansible_distribution | lower }}/{{ ansible_distribution_release }}/{{ rabbitmq_deb }}/download"
 
 erlang_deb: "erlang-{{ item }}_{{ erlang_version }}-1_amd64.deb"
-erlang_deb_url: "https://bintray.com/rabbitmq-erlang/debian/download_file?file_path=pool%2Ferlang%2F{{ erlang_version }}-1%2F{{ ansible_distribution | lower }}%2F{{ ansible_distribution_release }}%2Ferlang-{{ item }}_{{ erlang_version }}-1_amd64.deb"
+erlang_deb_url: "https://packages.erlang-solutions.com/erlang/debian/pool/erlang-{{ item }}_{{ erlang_version }}-1~{{ ansible_distribution | lower }}~{{ ansible_distribution_release }}_amd64.deb"
 
 # Will be used in loop to install specific packages required by RabbitMQ; ordering of these is very important
 erlang_deb_packages:


### PR DESCRIPTION
Repo for debian packages changed to https://packages.erlang-solutions.com since bintray shut down